### PR TITLE
ingest round trip POC

### DIFF
--- a/x-pack/plugins/siem/public/management/pages/policy/store/policy_details/selectors.ts
+++ b/x-pack/plugins/siem/public/management/pages/policy/store/policy_details/selectors.ts
@@ -6,6 +6,7 @@
 
 import { createSelector } from 'reselect';
 import { matchPath } from 'react-router-dom';
+import queryString from 'query-string';
 import { PolicyDetailsState } from '../../types';
 import {
   Immutable,
@@ -40,6 +41,10 @@ export const isOnPolicyDetailsPage = (state: Immutable<PolicyDetailsState>) => {
       exact: true,
     }) !== null
   );
+};
+
+export const returnToApp = (state: Immutable<PolicyDetailsState>) => {
+  return queryString.parse(state.location?.search ?? '')?.appReturn ?? '';
 };
 
 /** Returns the policyId from the url */

--- a/x-pack/plugins/siem/public/management/pages/policy/view/ingest_manager_integration/configure_datasource.tsx
+++ b/x-pack/plugins/siem/public/management/pages/policy/view/ingest_manager_integration/configure_datasource.tsx
@@ -18,7 +18,10 @@ export const ConfigureEndpointDatasource = memo<CustomConfigureDatasourceContent
     const { services } = useKibana();
     const pathname = useLocation().pathname.split('/');
     const policyId = pathname[pathname.length - 1];
-    const policyUrl = getManagementUrl({ name: 'policyDetails', policyId });
+    const policyUrl = `${getManagementUrl({
+      name: 'policyDetails',
+      policyId,
+    })}?appReturn=ingestManager`;
 
     return (
       <EuiEmptyPrompt

--- a/x-pack/plugins/siem/public/management/pages/policy/view/policy_details.tsx
+++ b/x-pack/plugins/siem/public/management/pages/policy/view/policy_details.tsx
@@ -23,6 +23,7 @@ import { useDispatch } from 'react-redux';
 import { usePolicyDetailsSelector } from './policy_hooks';
 import {
   policyDetails,
+  returnToApp,
   agentStatusSummary,
   updateStatus,
   isLoading,
@@ -42,7 +43,7 @@ import { getManagementUrl } from '../../../common/routing';
 
 export const PolicyDetails = React.memo(() => {
   const dispatch = useDispatch<(action: AppAction) => void>();
-  const { notifications } = useKibana();
+  const { notifications, services } = useKibana();
 
   // Store values
   const policyItem = usePolicyDetailsSelector(policyDetails);
@@ -50,10 +51,12 @@ export const PolicyDetails = React.memo(() => {
   const policyUpdateStatus = usePolicyDetailsSelector(updateStatus);
   const isPolicyLoading = usePolicyDetailsSelector(isLoading);
   const policyApiError = usePolicyDetailsSelector(apiError);
+  const shouldReturnToIngest = usePolicyDetailsSelector(returnToApp) === 'ingestManager';
 
   // Local state
   const [showConfirm, setShowConfirm] = useState<boolean>(false);
   const policyName = policyItem?.name ?? '';
+  const agentConfigId = policyItem?.config_id ?? '';
 
   // Handle showing update statuses
   useEffect(() => {
@@ -72,6 +75,10 @@ export const PolicyDetails = React.memo(() => {
             />
           ),
         });
+        if (shouldReturnToIngest)
+          services.application.navigateToApp('ingestManager', {
+            path: `#/configs/${agentConfigId}`,
+          });
       } else {
         notifications.toasts.danger({
           toastLifeTimeMs: 10000,


### PR DESCRIPTION
## Summary

A POC which serves to shows a workflow for editing the Endpoint datasource/policy
1) Choose to edit in Ingest app
2) Edit/Save in Security app
3) Return to Ingest app

This uses an approach where we'll supply and read a query param `appReturn` which will insc

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
